### PR TITLE
Iterate over full prediction fragments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,11 @@ commands =
 
 [testenv:load-test-models]
 commands =
-    python -m tests.load_models
+    python -W "ignore:Note the async API is not yet stable:FutureWarning" -m tests.load_models
 
 [testenv:unload-test-models]
 commands =
-    python -m tests.unload_models
+    python -W "ignore:Note the async API is not yet stable:FutureWarning" -m tests.unload_models
 
 [testenv:coverage]
 # Subprocess coverage based on https://hynek.me/articles/turbo-charge-tox/


### PR DESCRIPTION
Emit full prediction fragments from the streaming iteration API.

Also avoid emitting the async API stability warning from the test suite's
model loading and unloading helper comments.