### PR TITLE
Update project license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ dependencies = [
 requires-python = ">=3.11"
 
 readme = "README.md"
-license = {text = "Apache 2.0"}
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
* License is MIT, not Apache 2.0
* Use SPDX license expression instead of trove classifiers
* Explicitly specify license file location