### PR TITLE
Add default client access to convenience API

### DIFF
--- a/src/lmstudio/sync_api.py
+++ b/src/lmstudio/sync_api.py
@@ -137,6 +137,7 @@ __all__ = [
     "LLM",
     "SyncModelHandle",
     "PredictionStream",
+    "get_default_client",
     "embedding_model",
     "list_downloaded_models",
     "list_loaded_models",

--- a/tests/test_convenience_api.py
+++ b/tests/test_convenience_api.py
@@ -16,6 +16,12 @@ from .support import (
 
 
 @pytest.mark.lmstudio
+def test_get_default_client() -> None:
+    client = lm.get_default_client()
+    assert isinstance(client, lm.Client)
+
+
+@pytest.mark.lmstudio
 def test_llm_any() -> None:
     model = lm.llm()
     assert model.identifier in (EXPECTED_LLM_ID, EXPECTED_VLM_ID, TOOL_LLM_ID)


### PR DESCRIPTION
Exposing `lm.get_default_client()` means that *all* API operations are available in the convenience API, even if they don't have dedicated convenience API functions defined.