### PR TITLE
Avoid corrupting snake_case keys in JSON schemas

### DIFF
--- a/src/lmstudio/json_api.py
+++ b/src/lmstudio/json_api.py
@@ -1144,7 +1144,7 @@ class PredictionEndpoint(
                     config["rawTools"] = llm_tools.to_dict()
                 else:
                     config.raw_tools = llm_tools
-        config_stack = self._make_config_override(response_format, config)
+        structured, config_stack = self._make_config_override(response_format, config)
         params = PredictionChannelRequest._from_api_dict(
             {
                 "modelSpecifier": _model_spec_to_api_dict(model_specifier),
@@ -1155,7 +1155,7 @@ class PredictionEndpoint(
         super().__init__(params)
         # Status tracking for the prediction progress and result reporting
         self._is_cancelled = False
-        self._structured = response_format is not None
+        self._structured = structured
         self._on_message = on_message
         self._prompt_processing_progress = -1.0
         self._on_prompt_processing_progress = on_prompt_processing_progress
@@ -1172,7 +1172,7 @@ class PredictionEndpoint(
         cls,
         response_format: Type[ModelSchema] | DictSchema | None,
         config: LlmPredictionConfig | LlmPredictionConfigDict | None,
-    ) -> KvConfigStack:
+    ) -> tuple[bool, KvConfigStack]:
         return prediction_config_to_kv_config_stack(
             response_format, config, **cls._additional_config_options()
         )

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -82,22 +82,34 @@ SMALL_LLM_ID = "smollm2-135m-instruct"
 # Structured LLM responses
 ####################################################
 
+# Schema includes both snake_case and camelCase field
+# names to ensure the special-casing of snake_case
+# fields in dict inputs doesn't corrupt schema inputs
+SCHEMA_FIELDS = {
+    "response": {
+        "type": "string",
+    },
+    "first_word_in_response": {
+        "type": "string",
+    },
+    "lastWordInResponse": {
+        "type": "string",
+    },
+}
+SCHEMA_FIELD_NAMES = list(SCHEMA_FIELDS.keys())
+
 SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
-    "required": ["response"],
-    "properties": {
-        "response": {
-            "type": "string",
-        }
-    },
+    "required": SCHEMA_FIELD_NAMES,
+    "properties": SCHEMA_FIELDS,
     "additionalProperties": False,
 }
 RESPONSE_SCHEMA = {
     "$defs": {
         "schema": {
-            "properties": {"response": {"type": "string"}},
-            "required": ["response"],
+            "properties": SCHEMA_FIELDS,
+            "required": SCHEMA_FIELD_NAMES,
             "title": "schema",
             "type": "object",
         }
@@ -114,6 +126,8 @@ class OtherResponseFormat:
 
 class LMStudioResponseFormat(BaseModel):
     response: str
+    first_word_in_response: str
+    lastWordInResponse: str
 
 
 RESPONSE_FORMATS = (LMStudioResponseFormat, OtherResponseFormat, SCHEMA)

--- a/tests/sync/test_inference_sync.py
+++ b/tests/sync/test_inference_sync.py
@@ -22,6 +22,7 @@ from lmstudio import (
     Chat,
     DictSchema,
     LlmInfo,
+    LlmPredictionConfigDict,
     LlmPredictionFragment,
     LlmPredictionStats,
     LMStudioModelNotFoundError,
@@ -34,6 +35,8 @@ from ..support import (
     EXPECTED_LLM_ID,
     PROMPT,
     RESPONSE_FORMATS,
+    RESPONSE_SCHEMA,
+    SCHEMA_FIELDS,
     SHORT_PREDICTION_CONFIG,
     check_sdk_error,
 )
@@ -96,7 +99,7 @@ def test_complete_stream_sync(caplog: LogCap) -> None:
 
 @pytest.mark.lmstudio
 @pytest.mark.parametrize("format_type", RESPONSE_FORMATS)
-def test_complete_structured_sync(
+def test_complete_response_format_sync(
     format_type: Type[ModelSchema] | DictSchema, caplog: LogCap
 ) -> None:
     prompt = PROMPT
@@ -110,7 +113,34 @@ def test_complete_structured_sync(
     assert isinstance(response.content, str)
     assert isinstance(response.parsed, dict)
     assert response.parsed == json.loads(response.content)
-    assert "response" in response.parsed
+    assert SCHEMA_FIELDS.keys() == response.parsed.keys()
+
+
+@pytest.mark.lmstudio
+def test_complete_structured_config_sync(caplog: LogCap) -> None:
+    prompt = PROMPT
+    caplog.set_level(logging.DEBUG)
+    model_id = EXPECTED_LLM_ID
+    with Client() as client:
+        llm = client.llm.model(model_id)
+        config: LlmPredictionConfigDict = {
+            # snake_case keys are accepted at runtime,
+            # but the type hinted spelling is the camelCase names
+            # This test case checks the schema field name is converted,
+            # but *not* the snake_case and camelCase field names in the
+            # schema itself
+            "structured": {
+                "type": "json",
+                "json_schema": RESPONSE_SCHEMA,
+            }  # type: ignore[typeddict-item]
+        }
+        response = llm.complete(prompt, config=config)
+    assert isinstance(response, PredictionResult)
+    logging.info(f"LLM response: {response!r}")
+    assert isinstance(response.content, str)
+    assert isinstance(response.parsed, dict)
+    assert response.parsed == json.loads(response.content)
+    assert SCHEMA_FIELDS.keys() == response.parsed.keys()
 
 
 @pytest.mark.lmstudio

--- a/tests/test_kv_config.py
+++ b/tests/test_kv_config.py
@@ -419,7 +419,8 @@ def test_kv_stack_load_config_llm(config_dict: DictObject) -> None:
 def test_kv_stack_prediction_config(config_dict: DictObject) -> None:
     # MyPy complains here that it can't be sure the dict has all the right keys
     # It is correct about that, but we want to ensure it is handled at runtime
-    kv_stack = prediction_config_to_kv_config_stack(None, config_dict)  # type: ignore[arg-type]
+    structured, kv_stack = prediction_config_to_kv_config_stack(None, config_dict)  # type: ignore[arg-type]
+    assert structured
     assert kv_stack.to_dict() == EXPECTED_KV_STACK_PREDICTION
 
 


### PR DESCRIPTION
Also still report structured results at runtime when a response format is specified in the config (type hinted code still needs to use response_format for type checkers to correctly infer the type of `response.parsed`)