### PR TITLE
Publish config retrieval APIs

### DIFF
--- a/src/lmstudio/sync_api.py
+++ b/src/lmstudio/sync_api.py
@@ -66,6 +66,7 @@ from .history import (
 )
 from .json_api import (
     ActResult,
+    AnyLoadConfig,
     AnyModelSpecifier,
     AvailableModelBase,
     ChannelEndpoint,
@@ -121,7 +122,7 @@ from .json_api import (
     _model_spec_to_api_dict,
     _redact_json,
 )
-from ._kv_config import TLoadConfig, TLoadConfigDict, dict_from_fields_key
+from ._kv_config import TLoadConfig, TLoadConfigDict, parse_server_config
 from ._sdk_models import (
     EmbeddingRpcEmbedStringParameter,
     EmbeddingRpcTokenizeParameter,
@@ -866,7 +867,7 @@ class SyncSessionModel(
     def _files_session(self) -> _SyncSessionFiles:
         return self._client.files
 
-    def _get_load_config(self, model_specifier: AnyModelSpecifier) -> DictObject:
+    def _get_load_config(self, model_specifier: AnyModelSpecifier) -> AnyLoadConfig:
         """Get the model load config for the specified model."""
         # Note that the configuration reported here uses the *server* config names,
         # not the attributes used to set the configuration in the client SDK
@@ -876,7 +877,8 @@ class SyncSessionModel(
             }
         )
         config = self.remote_call("getLoadConfig", params)
-        return dict_from_fields_key(config)
+        result_type = self._API_TYPES.MODEL_LOAD_CONFIG
+        return result_type._from_any_api_dict(parse_server_config(config))
 
     def _get_api_model_info(self, model_specifier: AnyModelSpecifier) -> Any:
         """Get the raw model info (if any) for a model matching the given criteria."""
@@ -1339,7 +1341,7 @@ class SyncModelHandle(ModelHandleBase[TSyncSessionModel]):
 
     # Private until this API can emit the client config types
     @sdk_public_api()
-    def _get_load_config(self) -> DictObject:
+    def _get_load_config(self) -> AnyLoadConfig:
         """Get the model load config for this model."""
         return self._session._get_load_config(self.identifier)
 

--- a/tests/async/test_embedding_async.py
+++ b/tests/async/test_embedding_async.py
@@ -6,7 +6,7 @@ import anyio
 import pytest
 from pytest import LogCaptureFixture as LogCap
 
-from lmstudio import AsyncClient, LMStudioModelNotFoundError
+from lmstudio import AsyncClient, EmbeddingLoadModelConfig, LMStudioModelNotFoundError
 
 from ..support import (
     EXPECTED_EMBEDDING,
@@ -114,7 +114,7 @@ async def test_get_load_config_async(model_id: str, caplog: LogCap) -> None:
         response = await client.embedding._get_load_config(model_id)
     logging.info(f"Load config response: {response}")
     assert response
-    assert isinstance(response, dict)
+    assert isinstance(response, EmbeddingLoadModelConfig)
 
 
 @pytest.mark.asyncio

--- a/tests/async/test_inference_async.py
+++ b/tests/async/test_inference_async.py
@@ -15,6 +15,8 @@ from lmstudio import (
     Chat,
     DictSchema,
     LlmInfo,
+    LlmLoadModelConfig,
+    LlmPredictionConfig,
     LlmPredictionConfigDict,
     LlmPredictionFragment,
     LlmPredictionStats,
@@ -269,12 +271,12 @@ async def test_complete_prediction_metadata_async(caplog: LogCap) -> None:
     logging.info(f"LLM response: {response.content!r}")
     assert response.stats
     assert response.model_info
-    assert response._load_config
-    assert response._prediction_config
+    assert response.load_config
+    assert response.prediction_config
     assert isinstance(response.stats, LlmPredictionStats)
     assert isinstance(response.model_info, LlmInfo)
-    assert isinstance(response._load_config, dict)
-    assert isinstance(response._prediction_config, dict)
+    assert isinstance(response.load_config, LlmLoadModelConfig)
+    assert isinstance(response.prediction_config, LlmPredictionConfig)
 
 
 @pytest.mark.asyncio

--- a/tests/async/test_llm_async.py
+++ b/tests/async/test_llm_async.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 from pytest import LogCaptureFixture as LogCap
 
-from lmstudio import AsyncClient, history
+from lmstudio import AsyncClient, LlmLoadModelConfig, history
 
 from ..support import EXPECTED_LLM, EXPECTED_LLM_ID
 
@@ -96,7 +96,7 @@ async def test_get_load_config_async(model_id: str, caplog: LogCap) -> None:
         response = await client.llm._get_load_config(model_id)
     logging.info(f"Load config response: {response}")
     assert response
-    assert isinstance(response, dict)
+    assert isinstance(response, LlmLoadModelConfig)
 
 
 @pytest.mark.asyncio

--- a/tests/sync/test_embedding_sync.py
+++ b/tests/sync/test_embedding_sync.py
@@ -13,7 +13,7 @@ from contextlib import nullcontext
 import pytest
 from pytest import LogCaptureFixture as LogCap
 
-from lmstudio import Client, LMStudioModelNotFoundError
+from lmstudio import Client, EmbeddingLoadModelConfig, LMStudioModelNotFoundError
 
 from ..support import (
     EXPECTED_EMBEDDING,
@@ -115,7 +115,7 @@ def test_get_load_config_sync(model_id: str, caplog: LogCap) -> None:
         response = client.embedding._get_load_config(model_id)
     logging.info(f"Load config response: {response}")
     assert response
-    assert isinstance(response, dict)
+    assert isinstance(response, EmbeddingLoadModelConfig)
 
 
 @pytest.mark.lmstudio

--- a/tests/sync/test_inference_sync.py
+++ b/tests/sync/test_inference_sync.py
@@ -22,6 +22,8 @@ from lmstudio import (
     Chat,
     DictSchema,
     LlmInfo,
+    LlmLoadModelConfig,
+    LlmPredictionConfig,
     LlmPredictionConfigDict,
     LlmPredictionFragment,
     LlmPredictionStats,
@@ -264,12 +266,12 @@ def test_complete_prediction_metadata_sync(caplog: LogCap) -> None:
     logging.info(f"LLM response: {response.content!r}")
     assert response.stats
     assert response.model_info
-    assert response._load_config
-    assert response._prediction_config
+    assert response.load_config
+    assert response.prediction_config
     assert isinstance(response.stats, LlmPredictionStats)
     assert isinstance(response.model_info, LlmInfo)
-    assert isinstance(response._load_config, dict)
-    assert isinstance(response._prediction_config, dict)
+    assert isinstance(response.load_config, LlmLoadModelConfig)
+    assert isinstance(response.prediction_config, LlmPredictionConfig)
 
 
 @pytest.mark.lmstudio

--- a/tests/sync/test_llm_sync.py
+++ b/tests/sync/test_llm_sync.py
@@ -12,7 +12,7 @@ import logging
 import pytest
 from pytest import LogCaptureFixture as LogCap
 
-from lmstudio import Client, history
+from lmstudio import Client, LlmLoadModelConfig, history
 
 from ..support import EXPECTED_LLM, EXPECTED_LLM_ID
 
@@ -96,7 +96,7 @@ def test_get_load_config_sync(model_id: str, caplog: LogCap) -> None:
         response = client.llm._get_load_config(model_id)
     logging.info(f"Load config response: {response}")
     assert response
-    assert isinstance(response, dict)
+    assert isinstance(response, LlmLoadModelConfig)
 
 
 @pytest.mark.lmstudio

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -24,6 +24,8 @@ from lmstudio.history import (
 )
 from lmstudio.json_api import (
     LlmInfo,
+    LlmLoadModelConfig,
+    LlmPredictionConfig,
     LlmPredictionStats,
     PredictionResult,
     TPrediction,
@@ -347,8 +349,8 @@ def _make_prediction_result(data: TPrediction) -> PredictionResult[TPrediction]:
             trained_for_tool_use=False,
             max_context_length=32,
         ),
-        _load_config={},
-        _prediction_config={},
+        load_config=LlmLoadModelConfig(),
+        prediction_config=LlmPredictionConfig(),
     )
 
 


### PR DESCRIPTION
* model handles provide a public "get_load_config" method
* prediction results report the prediction config and model config

Part of #33