### PR TITLE
Simplify prediction API type hinting

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -28,7 +28,6 @@ from lmstudio.json_api import (
     LlmPredictionConfig,
     LlmPredictionStats,
     PredictionResult,
-    TPrediction,
 )
 
 from .support import IMAGE_FILEPATH, check_sdk_error
@@ -334,7 +333,7 @@ def test_add_entries_class_content() -> None:
     assert chat._get_history_for_prediction() == EXPECTED_HISTORY
 
 
-def _make_prediction_result(data: TPrediction) -> PredictionResult[TPrediction]:
+def _make_prediction_result(data: str | DictObject) -> PredictionResult:
     return PredictionResult(
         content=(data if isinstance(data, str) else json.dumps(data)),
         parsed=data,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -67,7 +67,7 @@ async def test_concurrent_predictions(caplog: LogCap, subtests: SubTests) -> Non
     async with AsyncClient() as client:
         session = client.llm
 
-        async def _request_response() -> PredictionResult[str]:
+        async def _request_response() -> PredictionResult:
             llm = await session.model(model_id)
             return await llm.respond(
                 history=history,
@@ -172,7 +172,7 @@ def test_tool_using_agent(caplog: LogCap) -> None:
         chat.add_user_message("What is the sum of 123 and 3210?")
         tools = [ADDITION_TOOL_SPEC]
         # Ensure ignoring the round index passes static type checks
-        predictions: list[PredictionResult[str]] = []
+        predictions: list[PredictionResult] = []
 
         act_result = llm.act(chat, tools, on_prediction_completed=predictions.append)
         assert len(predictions) > 1


### PR DESCRIPTION
With the addition of GBNF grammar structured response format support, structured responses are no longer required to contain valid JSON.

Accordingly, type hinting for prediction APIs has been simplified:

* `PredictionResult` is no longer a generic type
* instead, `parsed` is defined as a `str`/`dict` union field
* whether it is a dict or not is now solely determined at runtime (based on whether a schema was sent to the server, and the content field has been successfully parsed as a JSON response)
* other types that were only generic in the kind of prediction they returned are also now no longer generic
* prediction APIs no longer define overloads that attempt to infer whether the result will be structured or not (these were already inaccurate, as they only considered the `response_format` parameter, ignoring the `structured` field in the prediction config)

Closes #59 