### PR TITLE
Use Ubuntu 22.04 to run CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         # There's no platform specific SDK code, but explicitly check Windows anyway
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
 
     # Check https://github.com/actions/action-versions/tree/main/config/actions
     # for latest versions if the standard actions start emitting warnings


### PR DESCRIPTION
GitHub are in the process of removing the Ubuntu 20.04 runners