### PR TITLE
Add initial tool error handling test case

### DIFF
--- a/src/lmstudio/sync_api.py
+++ b/src/lmstudio/sync_api.py
@@ -1499,7 +1499,7 @@ class LLM(SyncModelHandle[SyncSessionLlm]):
         on_prediction_completed: Callable[[PredictionRoundResult], Any] | None = None,
         on_prompt_processing_progress: Callable[[float, int], Any] | None = None,
         handle_invalid_tool_request: Callable[
-            [LMStudioPredictionError, ToolCallRequest | None], str
+            [LMStudioPredictionError, ToolCallRequest | None], str | None
         ]
         | None = None,
     ) -> ActResult:


### PR DESCRIPTION
The SDK doesn't currently manage unhandled exceptions in tool calls.

Add an initial test case that suppresses the exception inside the tool call.

A subsequent PR will update the test case to provide this behaviour as the default behaviour.