### PR TITLE
Add max_parallel_tool_calls to .act() API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmstudio"
-version = "1.3.3.dev0"
+version = "1.4.0.dev0"
 description = "LM Studio Python SDK"
 authors = [
     {name = "LM Studio", email = "team@lmstudio.ai"},

--- a/src/lmstudio/__init__.py
+++ b/src/lmstudio/__init__.py
@@ -1,6 +1,6 @@
 """LM Studio Python SDK."""
 
-__version__ = "1.3.3.dev0"
+__version__ = "1.4.0.dev0"
 
 
 # In addition to publishing the main SDK client API,

--- a/src/lmstudio/sync_api.py
+++ b/src/lmstudio/sync_api.py
@@ -1281,6 +1281,7 @@ class LLM(SyncModelHandle[SyncSessionLlm]):
         tools: Iterable[ToolDefinition],
         *,
         max_prediction_rounds: int | None = None,
+        max_parallel_tool_calls: int | None = 1,
         config: LlmPredictionConfig | LlmPredictionConfigDict | None = None,
         preset: str | None = None,
         on_message: Callable[[AssistantResponse | ToolResultMessage], Any]
@@ -1351,7 +1352,7 @@ class LLM(SyncModelHandle[SyncSessionLlm]):
             on_prompt_processing_for_endpoint = _wrapped_on_prompt_processing_progress
         # Request predictions until no more tool call requests are received in response
         # (or the maximum number of prediction rounds is reached)
-        with ThreadPoolExecutor() as pool:
+        with ThreadPoolExecutor(max_parallel_tool_calls) as pool:
             for round_index in round_counter:
                 self._logger.debug(
                     "Starting .act() prediction round", round_index=round_index


### PR DESCRIPTION
* default to running multiple tool calls sequentially
* set max_parallel_tool_calls to opt back in to parallel execution