### PR TITLE
Drop async API stability warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ markers = [
 # Warnings should only be emitted when being specifically tested
 filterwarnings = [
     "error",
-    "ignore:.*the async API is not yet stable:FutureWarning"
 ]
 # Capture log info from network client libraries
 log_format = "%(asctime)s %(levelname)s %(message)s"

--- a/src/lmstudio/plugin/cli.py
+++ b/src/lmstudio/plugin/cli.py
@@ -44,9 +44,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     warnings.filterwarnings(
         "ignore", ".*the plugin API is not yet stable", FutureWarning
     )
-    warnings.filterwarnings(
-        "ignore", ".*the async API is not yet stable", FutureWarning
-    )
     log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(level=log_level)
     if not args.dev:

--- a/src/lmstudio/plugin/hooks/common.py
+++ b/src/lmstudio/plugin/hooks/common.py
@@ -18,7 +18,7 @@ from typing import (
 
 from anyio import move_on_after
 
-from ...async_api import AsyncSession
+from ...async_api import _AsyncSession
 from ...schemas import DictObject
 from ..._sdk_models import (
     # TODO: Define aliases at schema generation time
@@ -32,13 +32,13 @@ from ..config_schemas import BaseConfigSchema
 
 # Available as lmstudio.plugin.hooks.*
 __all__ = [
-    "AsyncSessionPlugins",
+    "_AsyncSessionPlugins",
     "TPluginConfigSchema",
     "TGlobalConfigSchema",
 ]
 
 
-class AsyncSessionPlugins(AsyncSession):
+class _AsyncSessionPlugins(_AsyncSession):
     """Async client session for the plugins namespace."""
 
     API_NAMESPACE = "plugins"
@@ -63,7 +63,7 @@ class HookController(Generic[TPluginRequest, TPluginConfigSchema, TGlobalConfigS
 
     def __init__(
         self,
-        session: AsyncSessionPlugins,
+        session: _AsyncSessionPlugins,
         request: TPluginRequest,
         plugin_config_schema: type[TPluginConfigSchema],
         global_config_schema: type[TGlobalConfigSchema],

--- a/src/lmstudio/plugin/hooks/prompt_preprocessor.py
+++ b/src/lmstudio/plugin/hooks/prompt_preprocessor.py
@@ -47,7 +47,7 @@ from ..._sdk_models import (
 )
 from ..config_schemas import BaseConfigSchema
 from .common import (
-    AsyncSessionPlugins,
+    _AsyncSessionPlugins,
     HookController,
     SendMessageCallback,
     ServerRequestError,
@@ -129,7 +129,7 @@ class PromptPreprocessorController(
 
     def __init__(
         self,
-        session: AsyncSessionPlugins,
+        session: _AsyncSessionPlugins,
         request: PromptPreprocessingRequest,
         plugin_config_schema: type[TPluginConfigSchema],
         global_config_schema: type[TGlobalConfigSchema],
@@ -210,7 +210,7 @@ class PromptPreprocessor(Generic[TPluginConfigSchema, TGlobalConfigSchema]):
         self._abort_events: dict[str, asyncio.Event] = {}
 
     async def process_requests(
-        self, session: AsyncSessionPlugins, notify_ready: Callable[[], Any]
+        self, session: _AsyncSessionPlugins, notify_ready: Callable[[], Any]
     ) -> None:
         """Create plugin channel and wait for server requests."""
         logger = self._logger
@@ -376,7 +376,7 @@ async def run_prompt_preprocessor(
     hook_impl: PromptPreprocessorHook,
     plugin_config_schema: type[BaseConfigSchema],
     global_config_schema: type[BaseConfigSchema],
-    session: AsyncSessionPlugins,
+    session: _AsyncSessionPlugins,
     notify_ready: Callable[[], Any],
 ) -> None:
     """Accept prompt preprocessing requests."""

--- a/src/lmstudio/plugin/hooks/token_generator.py
+++ b/src/lmstudio/plugin/hooks/token_generator.py
@@ -8,7 +8,7 @@ from ..._sdk_models import (
 
 from ..config_schemas import BaseConfigSchema
 from .common import (
-    AsyncSessionPlugins,
+    _AsyncSessionPlugins,
     HookController,
     TPluginConfigSchema,
     TGlobalConfigSchema,
@@ -36,7 +36,7 @@ async def run_token_generator(
     hook_impl: TokenGeneratorHook,
     plugin_config_schema: type[BaseConfigSchema],
     global_config_schema: type[BaseConfigSchema],
-    session: AsyncSessionPlugins,
+    session: _AsyncSessionPlugins,
     notify_ready: Callable[[], Any],
 ) -> None:
     """Accept token generation requests."""

--- a/src/lmstudio/plugin/hooks/tools_provider.py
+++ b/src/lmstudio/plugin/hooks/tools_provider.py
@@ -13,7 +13,7 @@ from ..._sdk_models import (
 
 from ..config_schemas import BaseConfigSchema
 from .common import (
-    AsyncSessionPlugins,
+    _AsyncSessionPlugins,
     HookController,
     TPluginConfigSchema,
     TGlobalConfigSchema,
@@ -43,7 +43,7 @@ async def run_tools_provider(
     hook_impl: ToolsProviderHook,
     plugin_config_schema: type[BaseConfigSchema],
     global_config_schema: type[BaseConfigSchema],
-    session: AsyncSessionPlugins,
+    session: _AsyncSessionPlugins,
     notify_ready: Callable[[], Any],
 ) -> None:
     """Accept tools provider session requests."""

--- a/src/lmstudio/plugin/runner.py
+++ b/src/lmstudio/plugin/runner.py
@@ -27,7 +27,7 @@ from .._sdk_models import (
 from .sdk_api import LMStudioPluginInitError, LMStudioPluginRuntimeError
 from .config_schemas import BaseConfigSchema
 from .hooks import (
-    AsyncSessionPlugins,
+    _AsyncSessionPlugins,
     TPluginConfigSchema,
     TGlobalConfigSchema,
     run_prompt_preprocessor,
@@ -55,7 +55,7 @@ HookRunner: TypeAlias = Callable[
         THookImpl,
         type[TPluginConfigSchema],
         type[TGlobalConfigSchema],
-        AsyncSessionPlugins,
+        _AsyncSessionPlugins,
         ReadyCallback,
     ],
     Awaitable[Any],
@@ -100,7 +100,7 @@ class PluginClient(AsyncClient):
 
     _ALL_SESSIONS = (
         # Plugin controller access all runs through a dedicated endpoint
-        AsyncSessionPlugins,
+        _AsyncSessionPlugins,
     )
 
     def _create_auth_message(self) -> DictObject:
@@ -111,9 +111,9 @@ class PluginClient(AsyncClient):
         return self._format_auth_message(self._client_id, self._client_key)
 
     @property
-    def plugins(self) -> AsyncSessionPlugins:
+    def plugins(self) -> _AsyncSessionPlugins:
         """Return the plugins API client session."""
-        return self._get_session(AsyncSessionPlugins)
+        return self._get_session(_AsyncSessionPlugins)
 
     async def _run_hook_impl(
         self,

--- a/src/lmstudio/sync_api.py
+++ b/src/lmstudio/sync_api.py
@@ -110,6 +110,7 @@ from .json_api import (
     _model_spec_to_api_dict,
     _redact_json,
 )
+from ._ws_impl import SyncFutureTimeout
 from ._ws_thread import AsyncWebsocketThread, SyncToAsyncWebsocketBridge
 from ._kv_config import TLoadConfig, TLoadConfigDict, parse_server_config
 from ._sdk_models import (
@@ -228,7 +229,7 @@ class SyncChannel(Generic[T]):
                 # (we can't easily suppress the SDK's own frames for iterators)
                 try:
                     message = self._get_message(self.timeout)
-                except TimeoutError:
+                except SyncFutureTimeout:
                     raise LMStudioTimeoutError from None
                 if message is None:
                     raise LMStudioWebsocketError("Client unexpectedly disconnected.")
@@ -284,7 +285,7 @@ class SyncRemoteCall:
         """Receive call response on the receive queue."""
         try:
             message = self._get_message(self.timeout)
-        except TimeoutError:
+        except SyncFutureTimeout:
             raise LMStudioTimeoutError from None
         if message is None:
             raise LMStudioWebsocketError("Client unexpectedly disconnected.")

--- a/tests/test_session_errors.py
+++ b/tests/test_session_errors.py
@@ -13,8 +13,8 @@ from lmstudio import (
     Client,
 )
 from lmstudio.async_api import (
-    AsyncSession,
-    AsyncSessionSystem,
+    _AsyncSession,
+    _AsyncSessionSystem,
 )
 from lmstudio.sync_api import (
     SyncLMStudioWebsocket,
@@ -34,7 +34,7 @@ from .support import (
 from .support.lmstudio import ErrFunc
 
 
-async def check_call_errors_async(session: AsyncSession) -> None:
+async def check_call_errors_async(session: _AsyncSession) -> None:
     # Remote calls on the underlying websocket are expected to fail when not connected
     with pytest.raises(
         LMStudioWebsocketError,
@@ -57,7 +57,7 @@ async def check_call_errors_async(session: AsyncSession) -> None:
 @pytest.mark.asyncio
 async def test_session_not_started_async(caplog: LogCap) -> None:
     caplog.set_level(logging.DEBUG)
-    session = AsyncSessionSystem(AsyncClient())
+    session = _AsyncSessionSystem(AsyncClient())
     # Sessions start out disconnected
     assert not session.connected
     # Check server call errors are reported as expected
@@ -69,7 +69,7 @@ async def test_session_not_started_async(caplog: LogCap) -> None:
 async def test_session_disconnected_async(caplog: LogCap) -> None:
     caplog.set_level(logging.DEBUG)
     client = AsyncClient()
-    session = AsyncSessionSystem(client)
+    session = _AsyncSessionSystem(client)
     async with client._task_manager, session:
         assert session.connected
     # Session is disconnected after use
@@ -82,7 +82,7 @@ async def test_session_disconnected_async(caplog: LogCap) -> None:
 async def test_session_closed_port_async(caplog: LogCap) -> None:
     caplog.set_level(logging.DEBUG)
     client = AsyncClient(closed_api_host())
-    session = AsyncSessionSystem(client)
+    session = _AsyncSessionSystem(client)
     # Sessions start out disconnected
     assert not session.connected
     # Should get an SDK exception rather than the underlying exception
@@ -101,7 +101,7 @@ async def test_session_nonresponsive_port_async(caplog: LogCap) -> None:
     caplog.set_level(logging.DEBUG)
     with nonresponsive_api_host() as api_host:
         client = AsyncClient(api_host)
-        session = AsyncSessionSystem(client)
+        session = _AsyncSessionSystem(client)
         # Sessions start out disconnected
         assert not session.connected
         # Should get an SDK exception rather than the underlying exception

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -12,9 +12,9 @@ from lmstudio import (
     LMStudioWebsocketError,
 )
 from lmstudio.async_api import (
-    AsyncLMStudioWebsocket,
-    AsyncSession,
-    AsyncSessionSystem,
+    _AsyncLMStudioWebsocket,
+    _AsyncSession,
+    _AsyncSessionSystem,
 )
 from lmstudio.sync_api import (
     SyncLMStudioWebsocket,
@@ -27,7 +27,7 @@ from lmstudio._ws_thread import AsyncWebsocketThread
 from .support import LOCAL_API_HOST
 
 
-async def check_connected_async_session(session: AsyncSession) -> None:
+async def check_connected_async_session(session: _AsyncSession) -> None:
     assert session.connected
     session_ws = session._lmsws
     assert session_ws is not None
@@ -50,7 +50,7 @@ async def check_connected_async_session(session: AsyncSession) -> None:
 async def test_session_cm_async(caplog: LogCap) -> None:
     caplog.set_level(logging.DEBUG)
     client = AsyncClient()
-    session = AsyncSessionSystem(client)
+    session = _AsyncSessionSystem(client)
     # Sessions start out disconnected
     assert not session.connected
     # Disconnecting should run without error
@@ -156,7 +156,7 @@ async def test_websocket_cm_async(caplog: LogCap) -> None:
     caplog.set_level(logging.DEBUG)
     auth_details = AsyncClient._format_auth_message()
     tm = AsyncTaskManager(on_activation=None)
-    lmsws = AsyncLMStudioWebsocket(tm, f"http://{LOCAL_API_HOST}/system", auth_details)
+    lmsws = _AsyncLMStudioWebsocket(tm, f"http://{LOCAL_API_HOST}/system", auth_details)
     # SDK client websockets start out disconnected
     assert not lmsws.connected
     # Entering the CM opens the websocket if it isn't already open

--- a/tests/unload_models.py
+++ b/tests/unload_models.py
@@ -10,7 +10,9 @@ from .support import (
     TOOL_LLM_ID,
 )
 
-AsyncSessionModel = lms.async_api.AsyncSessionEmbedding | lms.async_api.AsyncSessionLlm
+AsyncSessionModel = (
+    lms.async_api._AsyncSessionEmbedding | lms.async_api._AsyncSessionLlm
+)
 
 
 async def _unload_model(session: AsyncSessionModel, model_identifier: str) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -25,11 +25,11 @@ commands =
 
 [testenv:load-test-models]
 commands =
-    python -W "ignore:Note the async API is not yet stable:FutureWarning" -m tests.load_models
+    python -m tests.load_models
 
 [testenv:unload-test-models]
 commands =
-    python -W "ignore:Note the async API is not yet stable:FutureWarning" -m tests.unload_models
+    python -m tests.unload_models
 
 [testenv:coverage]
 # Subprocess coverage based on https://hynek.me/articles/turbo-charge-tox/


### PR DESCRIPTION
* mark some async types as internal implementation details
* fix a Python 3.10 compatibility issue in the sync API timeout handling

Closes #47