### PR TITLE
Feature/buffer input clean

### DIFF
--- a/src/lmstudio/history.py
+++ b/src/lmstudio/history.py
@@ -29,7 +29,7 @@ from typing_extensions import (
     # Native in 3.13+
     TypeIs,
     # Native in Python 3.12+
-    Buffer
+    Buffer,
 )
 
 from msgspec import to_builtins
@@ -555,10 +555,10 @@ def _get_file_details(src: LocalFileInput) -> Tuple[str, Buffer]:
         except TypeError:
             # Not a buffer protocol object, fall through to other checks
             pass
-    
+
     if hasattr(src, "read"):
         try:
-            data: Buffer = src.read()
+            data = src.read()
         except OSError as exc:
             # Note: OSError details remain available via raised_exc.__context__
             err_msg = f"Error while reading {src!r} ({exc!r})"

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ commands =
     ruff check {posargs} src/ tests/ examples/plugins
 
 [testenv:typecheck]
+groups = dev
 allowlist_externals = mypy
 commands =
     mypy --strict {posargs} src/ tests/


### PR DESCRIPTION
refactor: optimize file handling to avoid redundant buffer conversions
      
- Change _get_file_details() to return Buffer instead of bytes
- Add special handling for memory view inputs to avoid unnecessary conversion
- Support all buffer protocol objects (bytes, bytearray, memoryview, array.array, etc.)
- Update type annotations throughout to use Buffer type from typing_extensions
- Improve error messages to mention "buffer" instead of just "bytes"

This change reduces memory overhead when working with buffer protocol objects
by preserving memoryview objects instead of converting them to bytes unnecessarily.