### PR TITLE
Python 3.14: implicitly eager Struct annotations

### DIFF
--- a/src/lmstudio/schemas.py
+++ b/src/lmstudio/schemas.py
@@ -90,6 +90,12 @@ class BaseModel(Struct, omit_defaults=True, kw_only=True):
     # Allows structured predictions using a `pydantic.BaseModel` inspired format,
     # even in applications that don't otherwise depend on Pydantic
 
+    def __init_subclass__(cls, *args: Any, **kwds: Any) -> None:
+        # Eagerly populate annotations on Python 3.14+
+        # Workaround for https://github.com/lmstudio-ai/lmstudio-python/issues/153
+        cls.__annotations__
+        super().__init_subclass__()
+
     @classmethod
     def model_json_schema(cls) -> DictSchema:
         """Returns JSON Schema dict describing the format of this class."""
@@ -185,6 +191,12 @@ class LMStudioStruct(Generic[TWireFormat], Struct, omit_defaults=True, kw_only=T
     # * "None" fields should be omitted, not sent as "null"
     # * Allow non-default fields after default fields
     #
+
+    def __init_subclass__(cls, *args: Any, **kwds: Any) -> None:
+        # Eagerly populate annotations on Python 3.14+
+        # Workaround for https://github.com/lmstudio-ai/lmstudio-python/issues/153
+        cls.__annotations__
+        super().__init_subclass__(*args, **kwds)
 
     # This is actually defined in msgspec.Struct,
     # but is missing from the published type stubs:

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,8 +1,5 @@
 """Common test support interfaces and expected value definitions."""
 
-# Work around https://github.com/jcrist/msgspec/issues/847
-from __future__ import annotations
-
 import logging
 import sys
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,8 +1,5 @@
 """Test schema processing support."""
 
-# Work around https://github.com/jcrist/msgspec/issues/847
-from __future__ import annotations
-
 from typing import Any, Type
 
 import pytest


### PR DESCRIPTION
Ensure annotations are eagerly populated when defining `lmstudio.BaseModel` and `lmstudio.LMStudioStruct` subclasses

Works around #153